### PR TITLE
Added native image generation to build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,16 @@
+buildscript {
+	repositories {
+		maven {
+			url 'https://plugins.gradle.org/m2/'
+		}
+	}
+	dependencies {
+		classpath "gradle.plugin.org.mikeneck:graalvm-native-image-plugin:0.5.0"
+	}
+}
+
 apply plugin: 'java'
+apply plugin: "org.mikeneck.graalvm-native-image"
 
 version = '1.0'
 sourceCompatibility = 1.8
@@ -15,4 +27,18 @@ jar {
 
 dependencies {
 	
+}
+
+nativeImage {
+	graalVmHome = System.getProperty('java.home')
+	mainClass = 'sk.mhecko.ssl.SSLPoke'
+	executableName = 'sslpoke'
+	outputDirectory = file("$buildDir/bin")
+	arguments(
+			'-H:EnableURLProtocols=http,https',
+			'-H:+JNI',
+			'--no-fallback',
+			'--enable-all-security-services',
+			'--report-unsupported-elements-at-runtime'
+	)
 }


### PR DESCRIPTION
I've added native image generation because I was too lazy to put a script in /usr/local/bin. 😄 

To create the native image, run `gradle nativeImage`. The executable is named `sslpoke` and is placed in build/bin.

Note: at the moment I'm seeing the following error during image generation, but the application seems to be running correctly.

```
WARNING GR-10238: VarHandle for static field is currently not fully supported. Static field private static volatile java.lang.System$Logger jdk.internal.event.EventHelper.securityLogger is not properly marked for Unsafe access!
```

Thanks for writing this tool, it has helped me more times than I can count.